### PR TITLE
Add linkMode variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ It is tested and runs on `windows-latest`, `ubuntu-latest`, and `macos-latest`.
 | `path` | false | CHANGELOG.md | Path to relative to the root of the project to a CHANGELOG.md file in Keep a Changelog 1.0.0 format. Defaults to CHANGELOG.md in the root of the project. |
 | `mode` | false | readdata | Mode for the action. Should be one of `readdata`, `release`, or `addchange`. Defaults to `readdata`. |
 | `releaseVersion` | false |  | Version number to use when updating a changelog for release. Only valid for mode `release`. |
+| `linkMode` | false | GitHub | Link mode. Should be either `GitHub` or `None`. Only valid for `release` |
 | `changeType` | false |  | Type of change to add. Should be one of `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, or `Security`. Only valid for mode `addchange`. |
 | `changeValue` | false |  | Data for the change to add. Should be a single line string.  Only valid for mode `addchange`. |
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
   releaseVersion:
     description:  Version number to use when updating a changelog for release. Only valid for mode `release`.
     required: false
+  linkMode:
+    description: Link mode. Should be either `GitHub` or `None`. Only valid for `release`
+    required: false
+    default: GitHub
   changeType:
     description: Type of change to add. Should be one of `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, or `Security`. Only valid for mode `addchange`.
     required: false
@@ -41,6 +45,7 @@ runs:
         INPUT_RELEASEVERSION: ${{ inputs.releaseVersion }}
         INPUT_CHANGETYPE: ${{ inputs.changeType }}
         INPUT_CHANGEVALUE: ${{ inputs.changeValue }}
+        INPUT_LINKMODE: ${{ inputs.linkMode }}
     - name: Install Module
       id: installmodule
       run: . "$env:GITHUB_ACTION_PATH\src\steps\2_installmodule.ps1"
@@ -77,6 +82,7 @@ runs:
         INPUT_RELEASEVERSION: ${{ inputs.releaseVersion }}
         INPUT_CHANGETYPE: ${{ inputs.changeType }}
         INPUT_CHANGEVALUE: ${{ inputs.changeValue }}
+        INPUT_LINKMODE: ${{ inputs.linkMode }}
     - name: Read Data
       id: readdata
       run: . "$env:GITHUB_ACTION_PATH\src\steps\5_readdata.ps1"

--- a/src/steps/1_validateinputs.ps1
+++ b/src/steps/1_validateinputs.ps1
@@ -14,3 +14,7 @@ if (($env:INPUT_MODE -eq "release") -and (!$env:INPUT_RELEASEVERSION)) {
     Write-Host "Mode 'release' requires input 'releaseVersion'."
     throw "Input validation error."
 }
+if (($env:INPUT_MODE -eq "release") -and (!$env:INPUT_LINKMODE) -and ($env:INPUT_LINKMODE -eq "GitHub" -or $env:INPUT_LINKMODE -eq "None")) {
+    Write-Host "Mode 'release' requires input 'linkMode'."
+    throw "Input validation error."
+}

--- a/src/steps/4_release.ps1
+++ b/src/steps/4_release.ps1
@@ -2,4 +2,4 @@ Write-Host "Updating changelog for release..."
 
 $ResolvedPath = "$env:GITHUB_WORKSPACE\$env:INPUT_PATH"
 
-Update-Changelog -Path $ResolvedPath -ReleaseVersion $env:INPUT_RELEASEVERSION -LinkMode $env:INPUT_LINKMODE
+Update-Changelog -Path $ResolvedPath -ReleaseVersion $env:INPUT_RELEASEVERSION -LinkMode $env:

--- a/src/steps/4_release.ps1
+++ b/src/steps/4_release.ps1
@@ -2,4 +2,4 @@ Write-Host "Updating changelog for release..."
 
 $ResolvedPath = "$env:GITHUB_WORKSPACE\$env:INPUT_PATH"
 
-Update-Changelog -Path $ResolvedPath -ReleaseVersion $env:INPUT_RELEASEVERSION -LinkMode "GitHub"
+Update-Changelog -Path $ResolvedPath -ReleaseVersion $env:INPUT_RELEASEVERSION -LinkMode $env:INPUT_LINKMODE

--- a/src/steps/4_release.ps1
+++ b/src/steps/4_release.ps1
@@ -2,4 +2,4 @@ Write-Host "Updating changelog for release..."
 
 $ResolvedPath = "$env:GITHUB_WORKSPACE\$env:INPUT_PATH"
 
-Update-Changelog -Path $ResolvedPath -ReleaseVersion $env:INPUT_RELEASEVERSION -LinkMode $env:
+Update-Changelog -Path $ResolvedPath -ReleaseVersion $env:INPUT_RELEASEVERSION -LinkMode $env:INPUT_LINKMODE


### PR DESCRIPTION
In my monolithic repository, I'm integrating this action and faced a challenge since I don't utilize tags. Consequently, I'd like to specify the link mode when calling `Update-Changelog`. Upon reviewing [the documentation](https://github.com/natescherer/ChangelogManagement/blob/main/docs/Update-Changelog.md#-linkmode) for the associated cmdlet, I discovered the existence of the `None` option, but the Action lacked support for it. This pull request introduces a new variable, `linkMode`, that allows users to specify either `GitHub` or `None` based on their requirements. 